### PR TITLE
change window.calNewLocale when changing the user locale in settings

### DIFF
--- a/apps/web/pages/settings/my-account/general.tsx
+++ b/apps/web/pages/settings/my-account/general.tsx
@@ -1,4 +1,4 @@
-import { useSession, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { Controller, useForm } from "react-hook-form";
 
 import { getLayout } from "@calcom/features/settings/layouts/SettingsLayout";
@@ -67,8 +67,8 @@ const GeneralView = ({ localeProp, user }: GeneralViewProps) => {
       showToast(t("settings_updated_successfully"), "success");
       await update(res);
 
-      if (res.signOutUser) {
-        await signOut({ callbackUrl: "/auth/logout" });
+      if (res.locale) {
+        window.calNewLocale = res.locale;
       }
     },
     onError: () => {

--- a/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/loggedInViewer/updateProfile.handler.ts
@@ -116,12 +116,6 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
     signOutUser = true;
   }
 
-  const localeHasBeenChanged = data.locale && user.locale !== data.locale;
-
-  if (localeHasBeenChanged) {
-    signOutUser = true;
-  }
-
   const updatedUser = await prisma.user.update({
     where: {
       id: user.id,


### PR DESCRIPTION
this ensures we don't need to log out the current user, the language change will be visible when moving to a different page, as it was before.