### PR TITLE
INT-2070 migrate availability schedule page

### DIFF
--- a/apps/web/app/future/(no-layout)/availability/[schedule]/page.tsx
+++ b/apps/web/app/future/(no-layout)/availability/[schedule]/page.tsx
@@ -1,0 +1,3 @@
+import AvailabilitySchedulePage from "@pages/availability/[schedule]";
+
+export default AvailabilitySchedulePage;

--- a/apps/web/pages/availability/[schedule].tsx
+++ b/apps/web/pages/availability/[schedule].tsx
@@ -1,4 +1,6 @@
-import { useRouter, useSearchParams } from "next/navigation";
+"use client";
+
+import { useRouter, useParams } from "next/navigation";
 import { useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 
@@ -83,13 +85,13 @@ const DateOverride = ({ workingHours }: { workingHours: WorkingHours[] }) => {
 };
 
 export default function Availability() {
-  const searchParams = useSearchParams();
+  const params = useParams();
   const { t, i18n } = useLocale();
   const router = useRouter();
   const utils = trpc.useContext();
   const me = useMeQuery();
-  const scheduleId = searchParams?.get("schedule") ? Number(searchParams.get("schedule")) : -1;
-  const fromEventType = searchParams?.get("fromEventType");
+  const scheduleId = params?.["schedule"] ? Number(params["schedule"]) : -1;
+  const fromEventType = params?.["fromEventType"];
   const { timeFormat } = me.data || { timeFormat: null };
   const [openSidebar, setOpenSidebar] = useState(false);
   const { data: schedule, isLoading } = trpc.viewer.availability.schedule.get.useQuery(


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Restructure app router directory into `(layout)` and `(no-layout)` groups
- Migrate availability schedule page `availability/[schedule]`
- Make pages router availability directory legacy by renaming it to `legacy_availability`

## Requirement/Documentation

- https://nextjs.org/docs/app/building-your-application/routing/route-groups

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to `/availability` and choose any of your schedules and you will be navigated to `/availability/[schedule]`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.