### PR TITLE
fix: queryClient is not persisted

### DIFF
--- a/apps/web/app/_trpc/createTRPCNextLayout.ts
+++ b/apps/web/app/_trpc/createTRPCNextLayout.ts
@@ -103,18 +103,7 @@ export function createTRPCNextLayout<TRouter extends AnyRouter>(
     }
 
     if (key === "dehydrate") {
-      // if (queryClient.isFetching()) {
-      //   await new Promise<void>((resolve) => {
-      //     const unsub = queryClient.getQueryCache().subscribe((event) => {
-      //       if (event?.query.getObserversCount() === 0) {
-      //         resolve();
-      //         unsub();
-      //       }
-      //     });
-      //   });
-      // }
-      const dehydratedState = dehydrate(queryClient);
-      return () => transformer.serialize(dehydratedState);
+      return () => transformer.serialize(dehydrate(queryClient));
     }
 
     return createRecursiveProxy(async (callOpts) => {

--- a/apps/web/app/_trpc/createTRPCNextLayout.ts
+++ b/apps/web/app/_trpc/createTRPCNextLayout.ts
@@ -67,7 +67,7 @@ function getQueryKey(path: string[], input: unknown) {
   return input === undefined ? [path] : [path, input];
 }
 
-const getRequestStorage = <TRouter extends AnyRouter>(opts: CreateTRPCNextLayoutOptions<TRouter>) => {
+const getStateContainer = <TRouter extends AnyRouter>(opts: CreateTRPCNextLayoutOptions<TRouter>) => {
   let _trpc: {
     cache: unknown;
     queryClient: QueryClient;
@@ -90,11 +90,7 @@ const getRequestStorage = <TRouter extends AnyRouter>(opts: CreateTRPCNextLayout
 export function createTRPCNextLayout<TRouter extends AnyRouter>(
   opts: CreateTRPCNextLayoutOptions<TRouter>
 ): CreateTRPCNextLayout<TRouter> {
-  const getRequest = getRequestStorage(opts);
-
-  function getState() {
-    return getRequest();
-  }
+  const getState = getStateContainer(opts);
 
   const transformer = opts.transformer ?? {
     serialize: (v) => v,


### PR DESCRIPTION
 - previously queryClient was recreated on each getState call, and because of that dehydrate always returned empty object