### PR TITLE
chore: append the intuita CLI to the precommit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ apps/auth
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.intuita

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+yarn lint-staged --verbose
 
 yarn app-store:build && git add packages/app-store/*.generated.*

--- a/.intuitarc.json
+++ b/.intuitarc.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0.0",
+  "preCommitCodemods": []
+}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "dotenv-checker": "^1.1.5",
     "husky": "^8.0.0",
     "i18n-unused": "^0.13.0",
+    "intuita": "0.1.3",
     "jest-diff": "^29.5.0",
     "jsdom": "^22.0.0",
     "lint-staged": "^12.5.0",
@@ -117,6 +118,7 @@
   },
   "lint-staged": {
     "(apps|packages)/**/*.{js,ts,jsx,tsx}": [
+      "intuita runOnPreCommit --useCache",
       "prettier --write",
       "eslint --fix"
     ],


### PR DESCRIPTION
## What does this PR do?

This PR adds the intuita CLI as one of the executable scripts in the pre-commit hook managed by `lint-staged`. This allows users to execute selected codemods against staged files.

## Type of change
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [ ] This change requires a documentation update

## How should this be tested?
1. Install all the project dependencies.
2. Stage at least one JS/TS file within the `apps` or `packages` directory.
3. Commit the changes
4. Check that `intuita` is called by `lint-staged` in the subsequent step.
5. Since no codemods are configured, no staged files should be changed. No new files should be created.

## Mandatory Tasks
- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
