### PR TITLE
INT-2215 Migrate '/insights' page

### DIFF
--- a/apps/web/app/future/(individual-page-wrapper)/insights/page.tsx
+++ b/apps/web/app/future/(individual-page-wrapper)/insights/page.tsx
@@ -1,34 +1,39 @@
 import OldPage from "@pages/insights/index";
 import { _generateMetadata } from "app/_utils";
-import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
-import { headers, cookies } from "next/headers";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
 
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
-
-import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
 
 import PageWrapper from "@components/PageWrapperAppDir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
-    () => "",
-    () => ""
+    () => "Insights",
+    (t) => t("insights_subtitle")
   );
 
-type PageProps = Readonly<{
-  params: Params;
-}>;
+async function getData() {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
 
-const Page = async ({ params }: PageProps) => {
+  if (flags.insights === false) {
+    return notFound();
+  }
+
+  return {};
+}
+
+const Page = async () => {
   const h = headers();
   const nonce = h.get("x-nonce") ?? undefined;
 
-  const legacyCtx = buildLegacyCtx(params, headers(), cookies());
-  const props = await getData(legacyCtx);
+  await getData();
 
   return (
     <PageWrapper getLayout={getLayout} requiresLicense={false} nonce={nonce} themeBasis={null}>
-      <OldPage {...props} />
+      <OldPage />
     </PageWrapper>
   );
 };

--- a/apps/web/app/future/(individual-page-wrapper)/insights/page.tsx
+++ b/apps/web/app/future/(individual-page-wrapper)/insights/page.tsx
@@ -1,0 +1,36 @@
+import OldPage from "@pages/insights/index";
+import { _generateMetadata } from "app/_utils";
+import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import { headers, cookies } from "next/headers";
+
+import { getLayout } from "@calcom/features/MainLayoutAppDir";
+
+import { buildLegacyCtx } from "@lib/buildLegacyCtx";
+
+import PageWrapper from "@components/PageWrapperAppDir";
+
+export const generateMetadata = async () =>
+  await _generateMetadata(
+    () => "",
+    () => ""
+  );
+
+type PageProps = Readonly<{
+  params: Params;
+}>;
+
+const Page = async ({ params }: PageProps) => {
+  const h = headers();
+  const nonce = h.get("x-nonce") ?? undefined;
+
+  const legacyCtx = buildLegacyCtx(params, headers(), cookies());
+  const props = await getData(legacyCtx);
+
+  return (
+    <PageWrapper getLayout={getLayout} requiresLicense={false} nonce={nonce} themeBasis={null}>
+      <OldPage {...props} />
+    </PageWrapper>
+  );
+};
+
+export default Page;

--- a/apps/web/app/future/insights/page.tsx
+++ b/apps/web/app/future/insights/page.tsx
@@ -1,12 +1,10 @@
-import OldPage from "@pages/insights/index";
+import LegacyPage from "@pages/insights/index";
 import { _generateMetadata } from "app/_utils";
-import { headers } from "next/headers";
+import { WithLayout } from "app/layoutHOC";
 import { notFound } from "next/navigation";
 
 import { getLayout } from "@calcom/features/MainLayoutAppDir";
 import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
-
-import PageWrapper from "@components/PageWrapperAppDir";
 
 export const generateMetadata = async () =>
   await _generateMetadata(
@@ -25,17 +23,4 @@ async function getData() {
   return {};
 }
 
-const Page = async () => {
-  const h = headers();
-  const nonce = h.get("x-nonce") ?? undefined;
-
-  await getData();
-
-  return (
-    <PageWrapper getLayout={getLayout} requiresLicense={false} nonce={nonce} themeBasis={null}>
-      <OldPage />
-    </PageWrapper>
-  );
-};
-
-export default Page;
+export default WithLayout({ getLayout, getData, Page: LegacyPage });

--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import type { GetServerSidePropsContext } from "next";
-import { headers, cookies } from "next/headers";
-
 import { getLayout } from "@calcom/features/MainLayout";
 import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
 import {
@@ -25,51 +22,7 @@ import { RefreshCcw, UserPlus, Users } from "@calcom/ui/components/icon";
 
 import PageWrapper from "@components/PageWrapper";
 
-import { buildLegacyCtx } from "../../lib/buildLegacyCtx";
-
-type Params = {
-  [key: string]: string | string[] | undefined;
-};
-
-type PageProps = {
-  params: Params;
-};
-
-InsightsPage.PageWrapper = PageWrapper;
-InsightsPage.getLayout = getLayout;
-
-// If feature flag is disabled, return not found on getServerSideProps
-export const getServerSideProps = async () => {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-
-  if (flags.insights === false) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {},
-  };
-};
-
-async function getData(props: GetServerSidePropsContext) {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-
-  if (flags.insights === false) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {};
-}
-
-export default async function InsightsPage({ params }: PageProps) {
-  const legacyCtx = buildLegacyCtx(params, headers(), cookies());
-  await getData(legacyCtx);
+export default function InsightsPage() {
   const { t } = useLocale();
   const { data: user } = trpc.viewer.me.useQuery();
 
@@ -149,3 +102,22 @@ export default async function InsightsPage({ params }: PageProps) {
     </div>
   );
 }
+
+InsightsPage.PageWrapper = PageWrapper;
+InsightsPage.getLayout = getLayout;
+
+// If feature flag is disabled, return not found on getServerSideProps
+export const getServerSideProps = async () => {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
+
+  if (flags.insights === false) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {},
+  };
+};

--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import type { GetServerSidePropsContext } from "next";
+import { headers, cookies } from "next/headers";
+
 import { getLayout } from "@calcom/features/MainLayout";
 import { getFeatureFlagMap } from "@calcom/features/flags/server/utils";
 import {
@@ -20,7 +25,51 @@ import { RefreshCcw, UserPlus, Users } from "@calcom/ui/components/icon";
 
 import PageWrapper from "@components/PageWrapper";
 
-export default function InsightsPage() {
+import { buildLegacyCtx } from "../../lib/buildLegacyCtx";
+
+type Params = {
+  [key: string]: string | string[] | undefined;
+};
+
+type PageProps = {
+  params: Params;
+};
+
+InsightsPage.PageWrapper = PageWrapper;
+InsightsPage.getLayout = getLayout;
+
+// If feature flag is disabled, return not found on getServerSideProps
+export const getServerSideProps = async () => {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
+
+  if (flags.insights === false) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {},
+  };
+};
+
+async function getData(props: GetServerSidePropsContext) {
+  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
+  const flags = await getFeatureFlagMap(prisma);
+
+  if (flags.insights === false) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {};
+}
+
+export default async function InsightsPage({ params }: PageProps) {
+  const legacyCtx = buildLegacyCtx(params, headers(), cookies());
+  await getData(legacyCtx);
   const { t } = useLocale();
   const { data: user } = trpc.viewer.me.useQuery();
 
@@ -100,22 +149,3 @@ export default function InsightsPage() {
     </div>
   );
 }
-
-InsightsPage.PageWrapper = PageWrapper;
-InsightsPage.getLayout = getLayout;
-
-// If feature flag is disabled, return not found on getServerSideProps
-export const getServerSideProps = async () => {
-  const prisma = await import("@calcom/prisma").then((mod) => mod.default);
-  const flags = await getFeatureFlagMap(prisma);
-
-  if (flags.insights === false) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {},
-  };
-};

--- a/packages/lib/defaultEvents.ts
+++ b/packages/lib/defaultEvents.ts
@@ -106,9 +106,9 @@ const commons = {
 const dynamicEvent = {
   length: 30,
   slug: "dynamic",
-  title: "Dynamic",
-  eventName: "Dynamic Event",
-  description: "",
+  title: "Group Meeting",
+  eventName: "Group Meeting",
+  description: "Join us for a meeting with multiple people",
   descriptionAsSafeHTML: "",
   position: 0,
   ...commons,


### PR DESCRIPTION
This PR is on top of [[app-router-migration-1] chore: migrate the pages in `settings/admin` to the app directory](https://github.com/calcom/cal.com/pull/12561/commits/0c26303c3da97a6d01abb406edfa39360af387ef)

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- This PR migrates the `/insights` page to the app directory (which runs under the App Router).
- The migrated page exists under `/future` and is accessible at all times.

## Requirement/Documentation

- Performance metric for `/insights` page (App Router vs Pages Router) can be found [here](https://www.notion.so/intuita/Impact-Cal-App-Router-Migration-d122a75cd3424f39b4d81ab3809c9ca2?pvs=4#fc2f4a9fb5864d23884c3480ab9c7e15)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

1. Setup the environment variable `AB_TEST_BUCKET_PROBABILITY` to `100`
2. Setup the environment variable `APP_ROUTER_INSIGHTS_ENABLED` to `1`
3. Run the application
4. Navigate to `/insights`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.